### PR TITLE
chore: add type 'module' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@cosmostation/extension-client",
   "version": "0.1.9",
+  "type": "module",
   "description": "chrome extension cosmostation client",
   "scripts": {
     "tsc": "tsc",


### PR DESCRIPTION
### Description:
@ong-ar there seems to be some issue running the cosmostation library with [vite](https://github.com/vitejs/vite), causing unit test to fail.
```
SyntaxError: Cannot use import statement outside a module
Module .../node_modules/@cosmostation/extension-client/index.js:1 seems to be an ES Module but shipped in a CommonJS package. You might want to create an issue to the package "@cosmostation/extension-client" asking them to ship the file in .mjs extension or add "type": "module" in their package.json.

As a temporary workaround you can try to inline the package by updating your config:

// vitest.config.js
export default {
  test: {
    deps: {
      inline: [
        "@cosmostation/extension-client"
      ]
    }
  }
}
```

Added `type: module` to package.json in an attempt to resolve this.
Found an [article](http://net-informations.com/js/err/import.htm) describing this topic in detail.