### PR TITLE
chore: udapte ts config to compile in commonjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@cosmostation/extension-client",
-  "version": "0.1.9",
-  "type": "module",
+  "version": "0.1.10",
   "description": "chrome extension cosmostation client",
   "scripts": {
     "tsc": "tsc",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "jsx": "react-jsx",
-    "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "target": "ES2018",
+    "lib": ["dom", "dom.iterable", "ES2018"],
     "sourceMap": false,
     "declaration": true,
     "outDir": "dist",
@@ -12,7 +12,7 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
-    "module": "esnext",
+    "module": "commonjs",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "typeRoots": ["node_modules/@types", "src/types/d.ts"],


### PR DESCRIPTION
## This PR:
- update `ts-config` to compile code into CommonJS, adopting the same practice as the [cosmjs](https://github.com/cosmos/cosmjs/blob/main/tsconfig.json) package.

@ong-ar I've tested this on my [fork](https://www.npmjs.com/package/@thomasralee/cosmostation-extension-client) branch and can confirm that this resolves the issues vite and vitest were throwing.